### PR TITLE
Adds conversion of metric values to/from inclusive/exclusive

### DIFF
--- a/pycubexr/classes/cnode.py
+++ b/pycubexr/classes/cnode.py
@@ -20,8 +20,10 @@ class CNode(object):
     def add_child(self, child: 'CNode'):
         self._children.append(child)
 
-    def get_all_children(self) -> List['CNode']:
-        cnodes = [self]
+    def get_all_children(self, with_self=True) -> List['CNode']:
+        cnodes = []
+        if with_self:
+            cnodes.append(self)
         for child in self._children:
             cnodes += child.get_all_children()
         return cnodes

--- a/pycubexr/classes/metric_values.py
+++ b/pycubexr/classes/metric_values.py
@@ -1,6 +1,7 @@
 from typing import List, Any
 
 from pycubexr.classes import CNode, Metric
+from pycubexr.classes.metric import MetricType
 
 
 class MetricValues(object):
@@ -20,19 +21,19 @@ class MetricValues(object):
     def num_locations(self):
         return int(len(self.values) / len(self.cnode_indices))
 
-    def cnode_values(self, cnode: CNode, calculate_exclusive: bool = True):
+    def cnode_values(self, cnode: CNode, convert_to_exclusive: bool = True, convert_to_inclusive: bool = False):
         assert cnode.id in self.cnode_indices
         start_index = int(self.cnode_indices.index(cnode.id) * self.num_locations())
         end_index = start_index + self.num_locations()
         values = self.values[start_index:end_index]
-        if calculate_exclusive and self.metric.metric_type == MetricType.EXCLUSIVE:
+        if convert_to_exclusive and self.metric.metric_type == MetricType.EXCLUSIVE:
             values = self._calculate_exclusive(cnode, values)
         # Copy the list instead of returning the values to prevent the user changing the internal values
         return [value for value in values]
 
     def location_value(self, cnode: CNode, location_id: int):
         assert location_id < self.num_locations()
-        return self.cnode_values(cnode.id)[location_id]
+        return self.cnode_values(cnode)[location_id]
 
     def _calculate_exclusive(self, cnode: CNode, values: List[Any]):
         # Go over all cnode children and add the metric values
@@ -43,7 +44,7 @@ class MetricValues(object):
             values = [
                 x + y
                 for x, y
-                in zip(values, self.cnode_values(child_cnode, calculate_exclusive=False))
+                in zip(values, self.cnode_values(child_cnode, convert_to_exclusive=False))
             ]
         return values
 

--- a/pycubexr/classes/metric_values.py
+++ b/pycubexr/classes/metric_values.py
@@ -2,6 +2,7 @@ from typing import List, Any
 
 from pycubexr.classes import CNode, Metric
 from pycubexr.classes.metric import MetricType
+from pycubexr.utils.exceptions import InvalidConversionInstructionError
 
 
 class MetricValues(object):
@@ -21,30 +22,44 @@ class MetricValues(object):
     def num_locations(self):
         return int(len(self.values) / len(self.cnode_indices))
 
-    def cnode_values(self, cnode: CNode, convert_to_exclusive: bool = True, convert_to_inclusive: bool = False):
+    def cnode_values(self, cnode: CNode, convert_to_exclusive: bool = False, convert_to_inclusive: bool = False):
+        if convert_to_inclusive and convert_to_exclusive:
+            raise InvalidConversionInstructionError()
+        assert not (convert_to_inclusive and convert_to_exclusive)
         assert cnode.id in self.cnode_indices
         start_index = int(self.cnode_indices.index(cnode.id) * self.num_locations())
         end_index = start_index + self.num_locations()
         values = self.values[start_index:end_index]
-        if convert_to_exclusive and self.metric.metric_type == MetricType.EXCLUSIVE:
-            values = self._calculate_exclusive(cnode, values)
+
+        must_convert = ((convert_to_exclusive and self.metric.metric_type == MetricType.INCLUSIVE)
+                        or (convert_to_inclusive and self.metric.metric_type == MetricType.EXCLUSIVE))
+        if must_convert:
+            values = self._convert_values(cnode, values, to_inclusive=convert_to_inclusive)
         # Copy the list instead of returning the values to prevent the user changing the internal values
         return [value for value in values]
 
-    def location_value(self, cnode: CNode, location_id: int):
+    def location_value(self, cnode: CNode, location_id: int, convert_to_inclusive=False, convert_to_exclusive=False):
         assert location_id < self.num_locations()
-        return self.cnode_values(cnode)[location_id]
+        return self.cnode_values(
+            cnode,
+            convert_to_exclusive=convert_to_exclusive,
+            convert_to_inclusive=convert_to_inclusive
+        )[location_id]
 
-    def _calculate_exclusive(self, cnode: CNode, values: List[Any]):
+    def _convert_values(self, cnode: CNode, values: List[Any], to_inclusive: bool = True):
         # Go over all cnode children and add the metric values
         # Does NOT change the values array!
         for child_cnode in cnode.get_all_children(with_self=False):
             if child_cnode.id not in self.cnode_indices:
                 continue
             values = [
-                x + y
+                x + y if to_inclusive else x - y
                 for x, y
-                in zip(values, self.cnode_values(child_cnode, convert_to_exclusive=False))
+                in zip(values, self.cnode_values(
+                    child_cnode,
+                    convert_to_inclusive=False,
+                    convert_to_exclusive=False)
+                       )
             ]
         return values
 

--- a/pycubexr/classes/metric_values.py
+++ b/pycubexr/classes/metric_values.py
@@ -1,14 +1,18 @@
 from typing import List, Any
 
+from pycubexr.classes import CNode, Metric
+
 
 class MetricValues(object):
 
     def __init__(
             self,
             *,
+            metric: Metric,
             cnode_indices: List[int],
             values: List[Any]
     ):
+        self.metric = metric
         self.values = values
         self.cnode_indices = cnode_indices
         assert len(self.values) % len(self.cnode_indices) == 0
@@ -16,15 +20,32 @@ class MetricValues(object):
     def num_locations(self):
         return int(len(self.values) / len(self.cnode_indices))
 
-    def cnode_values(self, cnode_id: int):
-        assert cnode_id in self.cnode_indices
-        start_index = int(self.cnode_indices.index(cnode_id) * self.num_locations())
+    def cnode_values(self, cnode: CNode, calculate_exclusive: bool = True):
+        assert cnode.id in self.cnode_indices
+        start_index = int(self.cnode_indices.index(cnode.id) * self.num_locations())
         end_index = start_index + self.num_locations()
-        return self.values[start_index:end_index]
+        values = self.values[start_index:end_index]
+        if calculate_exclusive and self.metric.metric_type == MetricType.EXCLUSIVE:
+            values = self._calculate_exclusive(cnode, values)
+        # Copy the list instead of returning the values to prevent the user changing the internal values
+        return [value for value in values]
 
-    def location_value(self, cnode_id: int, location_id: int):
+    def location_value(self, cnode: CNode, location_id: int):
         assert location_id < self.num_locations()
-        return self.cnode_values(cnode_id)[location_id]
+        return self.cnode_values(cnode.id)[location_id]
+
+    def _calculate_exclusive(self, cnode: CNode, values: List[Any]):
+        # Go over all cnode children and add the metric values
+        # Does NOT change the values array!
+        for child_cnode in cnode.get_all_children(with_self=False):
+            if child_cnode.id not in self.cnode_indices:
+                continue
+            values = [
+                x + y
+                for x, y
+                in zip(values, self.cnode_values(child_cnode, calculate_exclusive=False))
+            ]
+        return values
 
     def __repr__(self):
         return 'MetricValues<{}>'.format(self.__dict__)

--- a/pycubexr/parsers/metrics_parser.py
+++ b/pycubexr/parsers/metrics_parser.py
@@ -18,6 +18,7 @@ def extract_metric_values(
         endianness_format_char=index.endianness_format
     )
     return MetricValues(
+        metric=metric,
         cnode_indices=index.cnode_indices,
         values=values
     )

--- a/pycubexr/parsers/tar_parser.py
+++ b/pycubexr/parsers/tar_parser.py
@@ -68,18 +68,29 @@ class CubexParser(object):
     def get_cnode(self, cnode_id: int) -> CNode:
         return [cnode for cnode in self._anchor_result.cnodes[0].get_all_children() if cnode.id == cnode_id][0]
 
+    def get_region_by_name(self, name: str):
+        return [region for region in self._anchor_result.regions if region.name == name][0]
+
+    def all_cnodes(self):
+        # TODO: is this always true?
+        assert len(self._anchor_result.cnodes) == 1
+        return self._anchor_result.cnodes[0].get_all_children()
+
+    def get_cnodes_for_region(self, region_id: int):
+        return [cnode for cnode in self.all_cnodes() if cnode.callee_region_id == region_id]
+
     def get_locations(self) -> List[Location]:
         return self._anchor_result.system_tree_nodes[0].all_locations()
-    
+
     def get_calltree(self, indent=0, cnode: CNode = None):
         if cnode is None:
             cnode = self._anchor_result.cnodes[0]
         call_tree_string = ""
         child_string = ""
-        child_string += "-"*indent + self.get_region(cnode).name
+        child_string += "-" * indent + self.get_region(cnode).name
         call_tree_string += child_string
         call_tree_string += "\n"
-        
+
         for child in cnode.get_children():
             tmp = self.get_calltree(indent + 1, cnode=child)
             if tmp is not None:

--- a/pycubexr/utils/exceptions.py
+++ b/pycubexr/utils/exceptions.py
@@ -10,3 +10,9 @@ class MissingMetricError(Exception):
 class CorruptIndexError(Exception):
     def __init__(self, message='Corrupt index.'):
         super().__init__(message)
+
+
+class InvalidConversionInstructionError(Exception):
+    def __init__(self, message="Received invalid conversion instruction. "
+                               "convert_to_exclusive and convert_to_inclusive must not be True at the same time."):
+        super().__init__(message)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="pycubexr",
-    version="1.0.0",
+    version="1.1.0",
     author="Extra-P project",
     author_email="extra-p@lists.parallel.informatik.tu-darmstadt.de",
     description="pyCubexR is a Python package for reading the Cube4 file format.",


### PR DESCRIPTION
As described in the [future work section for my project](https://github.com/extra-p/pycubexr/files/4930372/Parallel_Computing__pyCubexR.pdf), this contains code to convert from/to inclusive/exclusive metrics, i.e. metrics where the actual measurements of the child cnodes must be added to the parent node. 

:warning: This changes the method signature of `MetricValues.cnode_values` to take a `CNode` instance instead of the `cnode.id`.