### PR TITLE
Add support to read file information

### DIFF
--- a/pycubexr/classes/region.py
+++ b/pycubexr/classes/region.py
@@ -11,7 +11,8 @@ class Region(object):
             paradigm: str,
             role: str,
             url: str,
-            descr: str
+            descr: str,
+            mod: str
     ):
         self.id = _id
         self.begin = begin
@@ -22,6 +23,7 @@ class Region(object):
         self.role = role
         self.url = url
         self.description = descr
+        self.mod = mod
 
     def __repr__(self):
         return 'Region<{}>'.format(self.__dict__)

--- a/pycubexr/parsers/xml_parser_helper.py
+++ b/pycubexr/parsers/xml_parser_helper.py
@@ -37,6 +37,7 @@ def parse_region(xml_node: XMLNode):
         role=xml_node.findtext('role'),
         url=xml_node.findtext('url'),
         descr=xml_node.findtext('descr'),
+        mod=xml_node.get("mod"),
     )
 
 


### PR DESCRIPTION
The cubex files store file information but pycubexr currently cannot read it. I made small changes to some files to get that information. 

As you can see from the changes, the file information is stored as "mod" in the profile.cubex files.