### PR TITLE
Relax Numpy version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        "numpy~=1.18"
+        "numpy>=1.18"
     ]
 )


### PR DESCRIPTION
In my experience, pycubexr works just fine with NumPy 2.x. With this PR, I propose to relax the version requirement in `setup.py`.